### PR TITLE
fix: resolve detached HEAD and git add failures in sync-release workflow

### DIFF
--- a/.github/workflows/sync-release-version.yml
+++ b/.github/workflows/sync-release-version.yml
@@ -15,7 +15,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Switch to default branch
+        run: |
+          DEFAULT_BRANCH=$(git remote show origin | grep 'HEAD branch' | awk '{print $NF}')
+          echo "Default branch: $DEFAULT_BRANCH"
+          git checkout "$DEFAULT_BRANCH"
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -67,6 +72,8 @@ jobs:
             exit 0
           fi
 
-          git add package.json package-lock.json yarn.lock 2>/dev/null || true
+          git add package.json
+          [ -f package-lock.json ] && git add package-lock.json
+          [ -f yarn.lock ] && git add yarn.lock
           git commit -m "chore: bump version to ${{ steps.ver.outputs.version }} [skip ci]"
           git push


### PR DESCRIPTION
- Switch to default branch after checkout to avoid detached HEAD on tag events
- Add files individually to prevent git add from failing when yarn.lock is missing