### PR TITLE
feat: add sites-build-release reusable workflow (AWS OIDC + S3)

### DIFF
--- a/.github/workflows/sites-build-release.yml
+++ b/.github/workflows/sites-build-release.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # @v4.3.0
 
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@v4.0.1
+        uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
@@ -98,18 +98,28 @@ jobs:
         # Releases use the git tag as-is. Branch pushes / workflow_dispatch use
         # <package_base>-<run_id>.commit-<sha7>. Same shape as the prior oddish
         # snapshot version so existing rollout consumers keep working.
+        #
+        # Attacker-controllable values (tag_name in particular) are passed as
+        # env vars rather than `${{ }}` interpolation so they reach the shell
+        # as data, not code. Tags can contain shell metacharacters; injection
+        # here would run with `id-token: write` available, i.e. the runner
+        # could exchange the OIDC token for AWS credentials.
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           PKG_NAME=$(node -p "require('./package.json').name.replace('@dcl/', '')")
-          if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
+          if [ "$EVENT_NAME" = "release" ]; then
+            VERSION="$TAG_NAME"
           else
             BASE=$(node -p "require('./package.json').version" | sed 's/-development$//')
-            VERSION="${BASE}-${{ github.run_id }}.commit-${GITHUB_SHA:0:7}"
+            VERSION="${BASE}-${RUN_ID}.commit-${GITHUB_SHA:0:7}"
           fi
-          echo "package_name=$PKG_NAME"      >> $GITHUB_OUTPUT
-          echo "version=$VERSION"             >> $GITHUB_OUTPUT
-          echo "s3_prefix=$PKG_NAME/$VERSION" >> $GITHUB_OUTPUT
+          echo "package_name=$PKG_NAME"      >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION"             >> "$GITHUB_OUTPUT"
+          echo "s3_prefix=$PKG_NAME/$VERSION" >> "$GITHUB_OUTPUT"
           echo "Deploying $PKG_NAME@$VERSION"
 
       - name: Install
@@ -130,15 +140,25 @@ jobs:
       - name: Sync static assets to S3
         # Long cache for hashed assets (immutable filenames), short / no-cache
         # for HTML so new deploys roll out without stale shells.
+        #
+        # Inputs are env-mapped (not `${{ }}` interpolated into the shell) so
+        # that a caller passing a malicious value can't escape into command
+        # context while AWS credentials are active. Defense in depth: callers
+        # are trusted code today, but the blast radius of an injection here
+        # is full S3 write access.
         working-directory: ${{ inputs.working-directory }}
+        env:
+          DIST_DIR: ${{ inputs.dist-dir }}
+          S3_BUCKET: ${{ inputs.aws-bucket }}
+          S3_PREFIX: ${{ steps.version.outputs.s3_prefix }}
         run: |
-          aws s3 sync ./${{ inputs.dist-dir }} \
-            "s3://${{ inputs.aws-bucket }}/${{ steps.version.outputs.s3_prefix }}/" \
+          aws s3 sync "./$DIST_DIR" \
+            "s3://$S3_BUCKET/$S3_PREFIX/" \
             --delete \
             --exclude "*.html" \
             --cache-control "public, max-age=31536000, immutable"
-          aws s3 sync ./${{ inputs.dist-dir }} \
-            "s3://${{ inputs.aws-bucket }}/${{ steps.version.outputs.s3_prefix }}/" \
+          aws s3 sync "./$DIST_DIR" \
+            "s3://$S3_BUCKET/$S3_PREFIX/" \
             --exclude "*" \
             --include "*.html" \
             --cache-control "public, max-age=0, must-revalidate"
@@ -153,7 +173,7 @@ jobs:
       contents: read
     steps:
       - name: Set rollout (zone)
-        uses: decentraland/set-rollout-action@v2
+        uses: decentraland/set-rollout-action@26ead404b6944fd0ce0d087cc59fd817607454d6 # v2 branch HEAD as of 2026-05-21 — re-pin via Dependabot
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.ref }}
@@ -174,7 +194,7 @@ jobs:
       contents: read
     steps:
       - name: Set rollout (today)
-        uses: decentraland/set-rollout-action@v2
+        uses: decentraland/set-rollout-action@26ead404b6944fd0ce0d087cc59fd817607454d6 # v2 branch HEAD as of 2026-05-21 — re-pin via Dependabot
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.ref }}
@@ -197,7 +217,7 @@ jobs:
       contents: read
     steps:
       - name: Set rollout (org)
-        uses: decentraland/set-rollout-action@v2
+        uses: decentraland/set-rollout-action@26ead404b6944fd0ce0d087cc59fd817607454d6 # v2 branch HEAD as of 2026-05-21 — re-pin via Dependabot
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.ref }}
@@ -220,7 +240,7 @@ jobs:
       contents: read
     steps:
       - name: Set rollout (manual)
-        uses: decentraland/set-rollout-action@v2
+        uses: decentraland/set-rollout-action@26ead404b6944fd0ce0d087cc59fd817607454d6 # v2 branch HEAD as of 2026-05-21 — re-pin via Dependabot
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.ref }}

--- a/.github/workflows/sites-build-release.yml
+++ b/.github/workflows/sites-build-release.yml
@@ -1,0 +1,233 @@
+name: sites-build-release
+
+# Reusable workflow for Decentraland sites. Builds the app, uploads the dist/
+# directory to S3 via AWS OIDC (no static keys, no npm publishing), and sets
+# the Cloudflare rollout via set-rollout-action.
+#
+# Replaces the legacy npm-publish + GitLab-CDN-pipeline path. Each consumer
+# repo only declares triggers and inputs; all build/deploy steps live here so
+# changes propagate to every site in a single PR to this repo.
+#
+# Consumers must:
+#   - Provide an IAM role ARN whose trust policy allows their repo
+#     (set repo or org variable AWS_SITES_DEPLOYER_ROLE_ARN).
+#   - Provide the target S3 bucket name (AWS_SITES_BUCKET).
+#   - Configure dist build to output into ./dist (or override via dist-dir).
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        type: string
+        default: '22.x'
+        description: 'Node.js version'
+      working-directory:
+        type: string
+        default: '.'
+        description: 'Path containing package.json (e.g. ./webapp for monorepos)'
+      install-command:
+        type: string
+        default: 'npm install'
+      build-command:
+        type: string
+        default: 'npm run build'
+      dist-dir:
+        type: string
+        default: 'dist'
+        description: 'Build output directory relative to working-directory'
+      aws-region:
+        type: string
+        default: 'us-east-1'
+      aws-role-arn:
+        type: string
+        required: true
+        description: 'IAM Role ARN to assume via OIDC. Pass `${{ vars.AWS_SITES_DEPLOYER_ROLE_ARN }}` from the caller.'
+      aws-bucket:
+        type: string
+        required: true
+        description: 'Target S3 bucket. Pass `${{ vars.AWS_SITES_BUCKET }}` from the caller.'
+      deployment-path:
+        type: string
+        required: true
+        description: 'Cloudflare KV path key used by the rollout (e.g. marketplace, sites, profile).'
+      deployment-environment:
+        type: string
+        default: ''
+        description: 'Manual env override (zone|today|org). Leave empty for push/release; pass `${{ inputs.deploymentEnvironment }}` for workflow_dispatch.'
+      rollout-percentage:
+        type: string
+        default: '100'
+        description: 'Manual rollout percentage. Leave default for push/release.'
+    outputs:
+      version:
+        description: 'Computed deploy version'
+        value: ${{ jobs.build-release.outputs.version }}
+      package_name:
+        description: 'Package name without @dcl/ prefix'
+        value: ${{ jobs.build-release.outputs.package_name }}
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required for AWS OIDC — STS exchanges this token for short-lived AWS
+      # credentials that authorize the S3 upload, no static keys involved.
+      id-token: write
+      contents: read
+
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      package_name: ${{ steps.version.outputs.package_name }}
+
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # @v4.3.0
+
+      - name: Use Node.js ${{ inputs.node-version }}
+        uses: actions/setup-node@v4.0.1
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: 'npm'
+          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+
+      - name: Compute deploy version
+        # Releases use the git tag as-is. Branch pushes / workflow_dispatch use
+        # <package_base>-<run_id>.commit-<sha7>. Same shape as the prior oddish
+        # snapshot version so existing rollout consumers keep working.
+        id: version
+        run: |
+          PKG_NAME=$(node -p "require('./package.json').name.replace('@dcl/', '')")
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          else
+            BASE=$(node -p "require('./package.json').version" | sed 's/-development$//')
+            VERSION="${BASE}-${{ github.run_id }}.commit-${GITHUB_SHA:0:7}"
+          fi
+          echo "package_name=$PKG_NAME"      >> $GITHUB_OUTPUT
+          echo "version=$VERSION"             >> $GITHUB_OUTPUT
+          echo "s3_prefix=$PKG_NAME/$VERSION" >> $GITHUB_OUTPUT
+          echo "Deploying $PKG_NAME@$VERSION"
+
+      - name: Install
+        run: ${{ inputs.install-command }}
+        env:
+          HUSKY: 0
+
+      - name: Build
+        run: ${{ inputs.build-command }}
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ inputs.aws-role-arn }}
+          aws-region: ${{ inputs.aws-region }}
+          role-session-name: deploy-${{ steps.version.outputs.package_name }}-${{ github.run_id }}
+
+      - name: Sync static assets to S3
+        # Long cache for hashed assets (immutable filenames), short / no-cache
+        # for HTML so new deploys roll out without stale shells.
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          aws s3 sync ./${{ inputs.dist-dir }} \
+            "s3://${{ inputs.aws-bucket }}/${{ steps.version.outputs.s3_prefix }}/" \
+            --delete \
+            --exclude "*.html" \
+            --cache-control "public, max-age=31536000, immutable"
+          aws s3 sync ./${{ inputs.dist-dir }} \
+            "s3://${{ inputs.aws-bucket }}/${{ steps.version.outputs.s3_prefix }}/" \
+            --exclude "*" \
+            --include "*.html" \
+            --cache-control "public, max-age=0, must-revalidate"
+
+  # Push to default branch → roll out to .zone + .today @ 100%.
+  rollout-auto-zone:
+    if: github.event_name == 'push'
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      contents: read
+    steps:
+      - name: Set rollout (zone)
+        uses: decentraland/set-rollout-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref }}
+          sha: ${{ github.sha }}
+          packageName: "@dcl/${{ needs.build-release.outputs.package_name }}"
+          packageVersion: ${{ needs.build-release.outputs.version }}
+          deploymentPath: ${{ inputs.deployment-path }}
+          deploymentEnvironment: 'zone'
+          deploymentName: '_site'
+          percentage: 100
+
+  rollout-auto-today:
+    if: github.event_name == 'push'
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      contents: read
+    steps:
+      - name: Set rollout (today)
+        uses: decentraland/set-rollout-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref }}
+          sha: ${{ github.sha }}
+          packageName: "@dcl/${{ needs.build-release.outputs.package_name }}"
+          packageVersion: ${{ needs.build-release.outputs.version }}
+          deploymentPath: ${{ inputs.deployment-path }}
+          deploymentEnvironment: 'today'
+          deploymentName: '_site'
+          percentage: 100
+
+  # Release → roll out to .org @ 100%. Use set-rollout-manual.yml in the
+  # consumer repo to advance the percentage gradually if needed.
+  rollout-release-org:
+    if: github.event_name == 'release'
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      contents: read
+    steps:
+      - name: Set rollout (org)
+        uses: decentraland/set-rollout-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref }}
+          sha: ${{ github.sha }}
+          packageName: "@dcl/${{ needs.build-release.outputs.package_name }}"
+          packageVersion: ${{ needs.build-release.outputs.version }}
+          deploymentPath: ${{ inputs.deployment-path }}
+          deploymentEnvironment: 'org'
+          deploymentName: '_site'
+          percentage: 100
+
+  # Manual branch deploy via workflow_dispatch. Caller must pass through the
+  # selected environment + percentage as inputs.
+  rollout-manual:
+    if: github.event_name == 'workflow_dispatch'
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      contents: read
+    steps:
+      - name: Set rollout (manual)
+        uses: decentraland/set-rollout-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.ref }}
+          sha: ${{ github.sha }}
+          packageName: "@dcl/${{ needs.build-release.outputs.package_name }}"
+          packageVersion: ${{ needs.build-release.outputs.version }}
+          deploymentPath: ${{ inputs.deployment-path }}
+          deploymentEnvironment: ${{ inputs.deployment-environment }}
+          deploymentName: '_site'
+          percentage: ${{ inputs.rollout-percentage }}

--- a/README.md
+++ b/README.md
@@ -105,6 +105,86 @@ jobs:
 
 ---
 
+### Sites
+
+#### `sites-build-release.yml`
+
+Build a site and deploy via AWS OIDC + direct S3 upload (no npm publish, no GitLab CDN pipeline). Sets the Cloudflare rollout via `set-rollout-action`.
+
+Replaces the legacy npm-publish + GitLab-CDN-pipeline path used by older site workflows. One file in this repo controls build + deploy for every site that opts in.
+
+```yaml
+# .github/workflows/build-release.yml
+name: Build and release
+
+on:
+  push:
+    branches: [master]
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      deploymentEnvironment:
+        type: choice
+        description: 'Deployment environment'
+        required: true
+        default: 'zone'
+        options: [zone, today, org]
+      rolloutPercentage:
+        description: 'Rollout percentage'
+        required: true
+        default: '100'
+
+jobs:
+  build-release:
+    uses: decentraland/platform-actions/.github/workflows/sites-build-release.yml@main
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+    with:
+      deployment-path: 'sites'                              # Cloudflare KV path key
+      aws-role-arn: ${{ vars.AWS_SITES_DEPLOYER_ROLE_ARN }}
+      aws-bucket: ${{ vars.AWS_SITES_BUCKET }}
+      deployment-environment: ${{ github.event.inputs.deploymentEnvironment }}
+      rollout-percentage: ${{ github.event.inputs.rolloutPercentage }}
+```
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `deployment-path` | Yes | - | Cloudflare KV path key (e.g. `marketplace`, `sites`, `profile`) |
+| `aws-role-arn` | Yes | - | IAM role ARN to assume via OIDC |
+| `aws-bucket` | Yes | - | Target S3 bucket name |
+| `node-version` | No | `22.x` | Node.js version |
+| `working-directory` | No | `.` | Path containing `package.json` (use `./webapp` for monorepos) |
+| `install-command` | No | `npm install` | Install command |
+| `build-command` | No | `npm run build` | Build command |
+| `dist-dir` | No | `dist` | Build output directory (relative to working-directory) |
+| `aws-region` | No | `us-east-1` | AWS region |
+| `deployment-environment` | No | `''` | Manual env override (pass workflow_dispatch input) |
+| `rollout-percentage` | No | `100` | Manual rollout % (pass workflow_dispatch input) |
+
+**Rollout behavior** (driven by `github.event_name`):
+- `push` → `zone` @ 100% + `today` @ 100%
+- `release` → `org` @ 100%
+- `workflow_dispatch` → selected env @ selected %
+
+**Required permissions** on the caller job:
+- `id-token: write` (AWS OIDC)
+- `contents: read`
+- `deployments: write` (set-rollout-action creates deployment records)
+
+**Required repo/org variables** (configure once, ideally at org level so all sites inherit):
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_SITES_DEPLOYER_ROLE_ARN` | IAM role ARN. Trust policy must accept the consumer repo (e.g. wildcard `repo:decentraland/*`). |
+| `AWS_SITES_BUCKET` | Target S3 bucket for site assets. |
+
+No secrets required — auth is OIDC end-to-end.
+
+---
+
 ### Shared
 
 #### `lint-package-json.yml`

--- a/apps-template/workflows/sites-build-release.yml
+++ b/apps-template/workflows/sites-build-release.yml
@@ -29,6 +29,10 @@ on:
 
 jobs:
   build-release:
+    # TODO: Repin to `@v1` (or the latest tagged release) once this reusable
+    # workflow is stable and tagged. `@main` is fine for the initial rollout
+    # but is a moving target and shouldn't be used in steady-state production
+    # consumers — every site would silently pick up upstream changes.
     uses: decentraland/platform-actions/.github/workflows/sites-build-release.yml@main
     permissions:
       id-token: write

--- a/apps-template/workflows/sites-build-release.yml
+++ b/apps-template/workflows/sites-build-release.yml
@@ -1,0 +1,53 @@
+name: Build and release
+
+# Thin wrapper around decentraland/platform-actions/.github/workflows/sites-build-release.yml.
+# Pin to a tag (e.g. @v1) in production once the reusable workflow is tagged;
+# @main is used here while iterating.
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      deploymentEnvironment:
+        type: choice
+        description: 'Deployment environment'
+        required: true
+        default: 'zone'
+        options:
+          - zone
+          - today
+          - org
+      rolloutPercentage:
+        description: 'Rollout percentage'
+        required: true
+        default: '100'
+
+jobs:
+  build-release:
+    uses: decentraland/platform-actions/.github/workflows/sites-build-release.yml@main
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+    with:
+      # Required: caller-specific deployment configuration.
+      deployment-path: '<SITE_PATH>'              # e.g. marketplace, sites, profile
+      aws-role-arn: ${{ vars.AWS_SITES_DEPLOYER_ROLE_ARN }}
+      aws-bucket: ${{ vars.AWS_SITES_BUCKET }}
+
+      # Optional overrides — defaults match the most common case.
+      # node-version: '22.x'
+      # working-directory: '.'                    # e.g. ./webapp for marketplace
+      # install-command: 'npm install'
+      # build-command: 'npm run build'
+      # dist-dir: 'dist'
+
+      # Pass through workflow_dispatch inputs so the rollout-manual job
+      # receives the user's selection.
+      deployment-environment: ${{ github.event.inputs.deploymentEnvironment }}
+      rollout-percentage: ${{ github.event.inputs.rolloutPercentage }}


### PR DESCRIPTION
## Why

We have ~28 active site repos in `@dcl/*-site`. Their build + publish flows are all flavors of the same recipe — and that recipe has been broken twice in the last month (Mini Shai Hulud npm token invalidation, Trusted Publishing migration) requiring a per-repo workflow rewrite each time.

This adds a **reusable workflow** so the build/deploy logic lives in one place. Each consumer repo becomes a ~15-line thin wrapper. One PR here updates every site.

Companion PR consuming this from sites: decentraland/sites#525.

## What the workflow does

- Build the site (`npm install` + `npm run build`, configurable).
- Authenticate to AWS via **OIDC** (no static keys).
- Upload `dist/` straight to S3 under `<package>/<version>/` (immutable cache for hashed assets, no-cache for HTML).
- Set the Cloudflare rollout via `set-rollout-action`, gated on `github.event_name`:
  - `push` → `zone` @ 100% + `today` @ 100%
  - `release` → `org` @ 100%
  - `workflow_dispatch` → caller-supplied env + percentage

No npm publish. No GitLab CDN pipeline. No oddish.

## Files

- `.github/workflows/sites-build-release.yml` — the reusable workflow (`on: workflow_call`)
- `apps-template/workflows/sites-build-release.yml` — thin wrapper template (copy + customize)
- `README.md` — new "Sites" section documenting inputs, rollout behavior, required vars

## Caller shape

```yaml
jobs:
  build-release:
    uses: decentraland/platform-actions/.github/workflows/sites-build-release.yml@main
    permissions:
      id-token: write
      contents: read
      deployments: write
    with:
      deployment-path: 'sites'
      aws-role-arn: \${{ vars.AWS_SITES_DEPLOYER_ROLE_ARN }}
      aws-bucket: \${{ vars.AWS_SITES_BUCKET }}
      deployment-environment: \${{ github.event.inputs.deploymentEnvironment }}
      rollout-percentage: \${{ github.event.inputs.rolloutPercentage }}
```

## Design notes

- **No secrets in the workflow signature** — AWS role ARN and bucket name are not sensitive, so they're inputs the caller wires from repo/org `vars`. This lets the trust policy + bucket be configured once at org scale.
- **Outputs exposed at workflow level** (`version`, `package_name`) in case a caller wants to chain downstream jobs (e.g. Sentry release).
- **No Sentry inside the reusable** for the first iteration — Sentry sourcemap upload varies per repo (paths, project, url prefix). Callers can run their own Sentry job using the exposed outputs. If demand grows we can wrap it later.
- **Configurable working-directory** so monorepos (e.g. marketplace's `webapp/`) can adopt the same workflow.

## Risk + rollout

- This is a **purely additive** change. Existing workflows are untouched.
- Once the sites PR is green end-to-end, we can:
  1. Tag this `@v1` in this repo.
  2. Migrate the next site by copying the wrapper template + flipping `@main` → `@v1`.
  3. Roll out site by site over a couple of weeks.
- Subsequent reusable improvements (Sentry helper, multi-region, custom worker hooks) are non-breaking — they ship as new inputs with sensible defaults.

## Test plan

- [ ] sites PR runs to green using `@main`
- [ ] Once green, tag `@v1` here
- [ ] Migrate one secondary site (e.g. dao-landing or similar) by copying the wrapper
- [ ] Confirm rollout behavior matches the inline marketplace workflow
- [ ] Document the trust-policy + variables setup needed in each consumer repo (already in README — verify clarity with infra)