### PR TITLE
fix: stop release re-tagging commit SHA and block mutable/next deploy prd

### DIFF
--- a/.github/workflows/apps-docker-manual-deployment.yml
+++ b/.github/workflows/apps-docker-manual-deployment.yml
@@ -26,6 +26,19 @@ jobs:
     name: "Deploy to: ${{ inputs.deployment-environment }}"
     runs-on: ubuntu-latest
     steps:
+      # prd must run an immutable reference (a version tag or a digest). A mutable tag like
+      # latest/next can be repointed, or its digest GC'd out from under a running task, which
+      # is how dev broke (CannotPullContainerError). Block mutable tags on prd.
+      - name: Block mutable tags on prd
+        if: ${{ inputs.deployment-environment == 'prd' }}
+        env:
+          REGISTRY_PATH: ${{ inputs.quay-registry-path }}
+        run: |
+          case "$REGISTRY_PATH" in
+            *:latest|*:next|*:latest@*|*:next@*)
+              echo "::error::Refusing to deploy a mutable tag (latest/next) to prd. Pin an immutable version tag or a digest."
+              exit 1 ;;
+          esac
       - name: Trigger deployment
         id: deploy
         uses: decentraland/dcl-deploy-action@main

--- a/.github/workflows/apps-docker-manual-deployment.yml
+++ b/.github/workflows/apps-docker-manual-deployment.yml
@@ -34,9 +34,14 @@ jobs:
         env:
           REGISTRY_PATH: ${{ inputs.quay-registry-path }}
         run: |
+          # Block latest/next in any form, including digest-pinned (…:latest@sha256:…). A digest pin
+          # guarantees content but NOT persistence: once the latest/next tag moves off that digest and
+          # no retained tag remains, Quay GC reaps it and prd fails to pull on the next task placement
+          # (CannotPullContainerError) — this is the exact failure mode of the original incident. Only a
+          # retained immutable version tag keeps the digest alive, so prd must use one.
           case "$REGISTRY_PATH" in
             *:latest|*:next|*:latest@*|*:next@*)
-              echo "::error::Refusing to deploy a mutable tag (latest/next) to prd. Pin an immutable version tag or a digest."
+              echo "::error::Refusing to deploy a mutable tag (latest/next) to prd. Pin an immutable version tag."
               exit 1 ;;
           esac
       - name: Trigger deployment

--- a/.github/workflows/apps-docker-next.yml
+++ b/.github/workflows/apps-docker-next.yml
@@ -40,7 +40,19 @@ on:
         value: ${{ jobs.quay-build-push.registry-paths }}
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      # The next pipeline builds every push to main (unreviewed/untagged). It must never
+      # deploy to prd; prd is reached only through a GitHub release (apps-docker-release).
+      - name: Block prd from the next pipeline
+        if: ${{ inputs.deployment-environment == 'prd' }}
+        run: |
+          echo "::error::The 'next' pipeline must not deploy to prd. Cut a GitHub release (apps-docker-release) for prd."
+          exit 1
+
   quay-build-push:
+    needs: [guard]
     runs-on: ubuntu-latest
     outputs:
       registry-path: ${{ steps.push-to-quay.outputs.registry-path }}

--- a/.github/workflows/apps-docker-release.yml
+++ b/.github/workflows/apps-docker-release.yml
@@ -56,7 +56,19 @@ jobs:
         with:
           image: ${{ inputs.image-name || inputs.service-name }}
           layers: ${{ inputs.layers }}
-          tags: ${{ github.sha }} latest ${{ github.event.release.tag_name }} ${{ inputs.docker-tag }}
+          # Do NOT tag this rebuilt release image with ${{ github.sha }}. The next pipeline
+          # already published this commit under its SHA tag, and dev/biz deployments are pinned
+          # by digest to that next-built image. Re-tagging the SHA onto this (separately built)
+          # release digest moves the tag off the next-built digest, which then goes untagged ->
+          # Quay GC reaps it -> running tasks pinned to it fail with CannotPullContainerError.
+          # Release publishes version + latest only; the SHA tag stays on the next build.
+          #
+          # Order matters: the deploy job below pins the image by `registry-path`, which is the
+          # FIRST tag in this list, so it must be non-empty and prefer an immutable reference.
+          # On a release event: tag "<version> latest" (immutable version first).
+          # Off a release event (release.tag_name empty, e.g. MetaForge on push): tag just
+          # docker-tag (default "latest") so the first tag is valid and not duplicated.
+          tags: ${{ github.event.release.tag_name && format('{0} latest', github.event.release.tag_name) || inputs.docker-tag }}
           dockerfiles: |
             ./Dockerfile
           build-args: |

--- a/.github/workflows/apps-docker-release.yml
+++ b/.github/workflows/apps-docker-release.yml
@@ -1,4 +1,4 @@
-name: Publish 'latest' image
+name: Build, publish & deploy release image
 
 on:
   workflow_call:


### PR DESCRIPTION
- The release pipeline rebuilt each commit and re-tagged ${{ github.sha }} onto the new digest, orphaning the next-built digest that dev/biz deployments are pinned to; Quay GC then reaped it, causing CannotPullContainerError on the next task placement.
- Release now publishes version + latest only (immutable version as the first/registry-path tag), leaving the SHA tag on the next build.
- Adds guards so the next pipeline cannot deploy to prd and the manual-deployment workflow rejects mutable latest/next tags on prd.