### PR TITLE
chore: pin node 24 base images to sha256 digests

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,6 @@
 ARG RUN
 
-FROM node:lts-alpine as builderenv
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995 as builderenv
 
 RUN apk add --no-cache git
 
@@ -26,7 +26,7 @@ RUN yarn install --prod --frozen-lockfile
 
 ########################## END OF BUILD STAGE ##########################
 
-FROM node:lts-alpine
+FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995
 
 RUN apk update && apk upgrade
 RUN apk add --no-cache tini

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 ARG RUN
 
-FROM node:24-slim as builderenv
+FROM node:24-slim@sha256:c2d5ade763cacfb03fe9cb8e8af5d1be5041ff331921fa26a9b231ca3a4f780a as builderenv
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN yarn install --prod --frozen-lockfile
 
 ########################## END OF BUILD STAGE ##########################
 
-FROM node:24-slim
+FROM node:24-slim@sha256:c2d5ade763cacfb03fe9cb8e8af5d1be5041ff331921fa26a9b231ca3a4f780a
 
 RUN apt-get update
 RUN apt-get upgrade -y


### PR DESCRIPTION
pins the node 24 base images to immutable sha256 digests for reproducible builds:

- `Dockerfile.alpine`: `node:24-alpine@sha256:5fa278c5…` (builderenv + runtime stages)
- `Dockerfile.ubuntu`: `node:24-slim@sha256:c2d5ade7…` (builderenv + runtime stages)

signed-commit replacement for #57, which cannot be merged because its commits are not verified. same diff, supersedes #57.