### PR TITLE
fix: bump apps-docs node default to 24 so gitbook cli installs

### DIFF
--- a/.github/workflows/apps-docs.yml
+++ b/.github/workflows/apps-docs.yml
@@ -22,7 +22,7 @@ on:
       node-version:
         required: false
         type: string
-        default: "20"
+        default: "24"
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
## what

bumps the `node-version` default in `apps-docs.yml` from `20` to `24`.

## why

the docs publish job defaulted to node 20, but `@gitbook/cli` now pulls in `miniflare@4.x` which requires `node >=22`. the `install gitbook cli` step (`yarn global add @gitbook/cli`) fails on node 20 with:

```
error miniflare@4.20260609.0: The engine "node" is incompatible with this module. Expected version ">=22.0.0". Got "20.20.2"
error Found incompatible module.
```

node 20 was always going to break here once `@gitbook/cli` bumped its transitive `miniflare` to require node >=22.

## impact

this reusable workflow is consumed via `@main`, so the fix applies to **all** repos that call `apps-docs.yml` without overriding `node-version` (e.g. lamb2). the single `setup node.js` step sets the version for the whole docs job (validate / bundle / install / publish); raising it to 24 is safe since this job only lints and bundles the openapi spec and publishes to gitbook — it does not build any app.

24 is the current lts and matches the recent node 24 work in this repo.