### PR TITLE
chore: bump Node.js to v24 latest (v24.18.0)

### DIFF
--- a/.github/workflows/apps-build.yml
+++ b/.github/workflows/apps-build.yml
@@ -6,7 +6,7 @@ on:
       node-version:
         required: false
         type: string
-        default: "18.x"
+        default: "24"
         description: "Node.js version to use"
 
 jobs:

--- a/.github/workflows/apps-with-db-build.yml
+++ b/.github/workflows/apps-with-db-build.yml
@@ -6,7 +6,7 @@ on:
       node-version:
         required: false
         type: string
-        default: "18.x"
+        default: "24"
         description: "Node.js version to use"
 
 jobs:

--- a/.github/workflows/lint-package-json.yml
+++ b/.github/workflows/lint-package-json.yml
@@ -6,7 +6,7 @@ on:
       node-version:
         required: false
         type: string
-        default: '20.x'
+        default: '24'
         description: 'Node.js version to use'
       working-directory:
         required: false

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,6 @@
 ARG RUN
 
-FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995 as builderenv
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd as builderenv
 
 RUN apk add --no-cache git
 
@@ -26,7 +26,7 @@ RUN yarn install --prod --frozen-lockfile
 
 ########################## END OF BUILD STAGE ##########################
 
-FROM node:24-alpine@sha256:5fa278c599dbba0c8f873d8717d50ecbb57c5ae6a53b7ab240c25135e0b65995
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 RUN apk update && apk upgrade
 RUN apk add --no-cache tini

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 ARG RUN
 
-FROM node:24-slim@sha256:c2d5ade763cacfb03fe9cb8e8af5d1be5041ff331921fa26a9b231ca3a4f780a as builderenv
+FROM node:24-slim@sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc as builderenv
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN yarn install --prod --frozen-lockfile
 
 ########################## END OF BUILD STAGE ##########################
 
-FROM node:24-slim@sha256:c2d5ade763cacfb03fe9cb8e8af5d1be5041ff331921fa26a9b231ca3a4f780a
+FROM node:24-slim@sha256:b31e7a42fdf8b8aa5f5ed477c72d694301273f1069c5a2f71d53c6482e99a2fc
 
 RUN apt-get update
 RUN apt-get upgrade -y

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ No secrets required.
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `node-version` | No | `18.x` | Node.js version to use |
+| `node-version` | No | `24` | Node.js version to use |
 | `working-directory` | No | `.` | Directory that contains `package.json` |
 
 ---
@@ -172,12 +172,12 @@ jobs:
   build:
     uses: decentraland/platform-actions/.github/workflows/apps-with-db-build.yml@main
     with:
-      node-version: '20.x'
+      node-version: '24'
 ```
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `node-version` | No | `18.x` | Node.js version to use |
+| `node-version` | No | `24` | Node.js version to use |
 
 PostgreSQL connection string is exposed as `PG_COMPONENT_PSQL_CONNECTION_STRING`.
 
@@ -353,7 +353,7 @@ jobs:
 | `api-spec-file` | Yes | - | Path to OpenAPI spec file |
 | `api-spec-name` | Yes | - | API name in GitBook |
 | `output-bundle-file` | No | `docs/api-reference.yaml` | Bundled output path |
-| `node-version` | No | `20` | Node.js version |
+| `node-version` | No | `24` | Node.js version |
 
 Requires `GITBOOK_TOKEN` and `GITBOOK_ORGANIZATION_ID` org secrets.
 


### PR DESCRIPTION
## What

Brings all Node.js usage in this repo to the latest v24 (**v24.18.0**, what the `24` tags currently resolve to).

### Docker base images re-pinned to fresh v24 digests
- `Dockerfile.alpine` — `node:24-alpine` → `@sha256:a0b9bf06…54fbfd` (build + runtime stages)
- `Dockerfile.ubuntu` — `node:24-slim` → `@sha256:b31e7a42…99a2fc` (build + runtime stages)

Digests were pulled live from Docker Hub and verified to run `v24.18.0`.

### Reusable-workflow `node-version` defaults bumped to `24`
- `apps-build.yml` (`18.x` → `24`)
- `apps-with-db-build.yml` (`18.x` → `24`)
- `lint-package-json.yml` (`20.x` → `24`)

### README
Synced all three default tables plus the usage example to `24`, and fixed pre-existing doc drift — the `apps-docs` table listed `20` while the workflow already defaulted to `24`.

## ⚠️ Downstream impact

Any consumer relying on the **default** of these three reusable workflows will now build/test on Node 24 instead of 18/20. The hardcoded-`24` workflows (`libs-build-and-publish`, `npm-deprecate`, `sync-release-version`) and `apps-docs` were already on 24 and are untouched.